### PR TITLE
Updated Travis CI Images and removed macOS 10.14 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: c
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: focal
       compiler: gcc
     - os: linux
       dist: focal
+      compiler: clang
+    - os: osx
+      osx_image: xcode12
       compiler: clang
     - os: osx
       osx_image: xcode12.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: c
 
 jobs:
   include:
-    - name: Ubuntu (GCC)
+    - name: Ubuntu 20.04 (GCC)
       os: linux
       dist: focal
       compiler: gcc
-    - name: Ubuntu (Clang)
+    - name: Ubuntu 20.04 (Clang)
       os: linux
       dist: focal
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ addons:
       - argp-standalone
     update: true
 
+before_script:
+  - if [[ $CC == "clang" ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
+
 script:
   - cmake --version
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
     update: true
 
 before_script:
-  - if [[ $CC == "clang" ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $CC == "clang" ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
 
 script:
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       dist: focal
       compiler: clang
     - os: osx
-      osx_image: xcode12.2
+      osx_image: xcode12.3
       compiler: clang
 
 env:
@@ -37,18 +37,7 @@ before_script:
 
 script:
   - cmake --version
-  - |
-    # For Mojave (10.14)
-    # Source: https://github.com/henry0312/LightGBM/blob/master/docs/Installation-Guide.rst#apple-clang
-    if [[ "$TRAVIS_OS_NAME" == "osx" && ("$TRAVIS_OSX_IMAGE" == "xcode10.3" || \
-          "$TRAVIS_OSX_IMAGE" == "xcode11.2") ]]; then cmake \
-      -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
-      -DOpenMP_C_LIB_NAMES="omp" \
-      -DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib \
-      ./CMakeLists.txt
-    else
-      cmake ./CMakeLists.txt
-    fi
+  - cmake ./CMakeLists.txt
   - cmake --build .
   - ./aes256_test
   - ./aes_validator --usage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ language: c
 
 jobs:
   include:
-    - os: linux
+    - name: Ubuntu (GCC)
+      os: linux
       dist: focal
       compiler: gcc
-    - os: linux
+    - name: Ubuntu (Clang)
+      os: linux
       dist: focal
       compiler: clang
-    - os: osx
+    - name: macOS 10.15.7 (Xcode 12.0.7)
+      os: osx
       osx_image: xcode12
       compiler: clang
-    - os: osx
+    - name: macOS 11.1 (Xcode 12.3)
+      os: osx
       osx_image: xcode12.3
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       os: linux
       dist: focal
       compiler: clang
-    - name: macOS 10.15.7 (Catalina, Xcode 12.0.7)
+    - name: macOS 10.15.7 (Catalina, Xcode 12.0.1)
       os: osx
       osx_image: xcode12
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ jobs:
       os: linux
       dist: focal
       compiler: clang
-    - name: macOS 10.15.7 (Xcode 12.0.7)
+    - name: macOS 10.15.7 (Cataline, Xcode 12.0.7)
       os: osx
       osx_image: xcode12
       compiler: clang
-    - name: macOS 11.1 (Xcode 12.3)
+    - name: macOS 11.1 (Big Sur, Xcode 12.3)
       os: osx
       osx_image: xcode12.3
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,13 @@ language: c
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: focal
       compiler: gcc
     - os: linux
-      dist: xenial
+      dist: focal
       compiler: clang
     - os: osx
-      osx_image: xcode10.3
-      compiler: clang
-    - os: osx
-      osx_image: xcode11.3
+      osx_image: xcode12.2
       compiler: clang
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       os: linux
       dist: focal
       compiler: clang
-    - name: macOS 10.15.7 (Cataline, Xcode 12.0.7)
+    - name: macOS 10.15.7 (Catalina, Xcode 12.0.7)
       os: osx
       osx_image: xcode12
       compiler: clang


### PR DESCRIPTION
* Updated Travis CI Ubuntu to 20.04
* Updated Travis CI macOS 10.15 (Catalina, Xcode 12.0.1) and 11.1 (Big Sur, Xcode 12.3)
* Removed official testing support for macOS 10.14 (Mojave)
* Removed Travis CI CMake workaround for Mojave